### PR TITLE
Increase request body limit to 2mb for webhooks route

### DIFF
--- a/apps/node-fastify/src/routes/webhooks.ts
+++ b/apps/node-fastify/src/routes/webhooks.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 
 export default async function routes(fastify: FastifyInstance) {
   fastify.post('/webhooks', {
+    bodyLimit: 2097152,
     handler: async (request, reply) => {
       const headers = request.headers;
       const body: { raw: Buffer } = request.body as { raw: Buffer };


### PR DESCRIPTION
Increase the request body limit for route `/webhooks` from 1mb (default) to 2mb. We want to make sure that we won't run into error `413-PayloadTooLarge` in the future.