### PR TITLE
fix:replace automatic pagination with manual pagination

### DIFF
--- a/packages/orb-sync-lib/src/sync/credit_notes.ts
+++ b/packages/orb-sync-lib/src/sync/credit_notes.ts
@@ -24,8 +24,12 @@ export async function fetchAndSyncCreditNotes(
 ): Promise<number> {
   const creditNotes = [];
 
-  for await (const creditNote of orbClient.creditNotes.list({ limit: params.limit || 100 })) {
-    creditNotes.push(creditNote);
+  let creditNotesPage = await orbClient.creditNotes.list({ limit: params.limit || 100 });
+  creditNotes.push(...creditNotesPage.data);
+
+  while (creditNotesPage.hasNextPage()) {
+    creditNotesPage = await creditNotesPage.getNextPage();
+    creditNotes.push(...creditNotesPage.data);
   }
 
   await syncCreditNotes(postgresClient, creditNotes);

--- a/packages/orb-sync-lib/src/sync/plans.ts
+++ b/packages/orb-sync-lib/src/sync/plans.ts
@@ -17,14 +17,19 @@ export async function fetchAndSyncPlans(
 ): Promise<number> {
   const plans = [];
 
-  for await (const plan of orbClient.plans.list({
+  let plansPage = await orbClient.plans.list({
     limit: params.limit || 100,
     'created_at[gt]': params.createdAtGt,
     'created_at[gte]': params.createdAtGte,
     'created_at[lt]': params.createdAtLt,
     'created_at[lte]': params.createdAtLte,
-  })) {
-    plans.push(plan);
+  });
+
+  plans.push(...plansPage.data);
+
+  while (plansPage.hasNextPage()) {
+    plansPage = await plansPage.getNextPage();
+    plans.push(...plansPage.data);
   }
 
   await syncPlans(postgresClient, plans);


### PR DESCRIPTION
For whatever reason automatic pagination (using `for await`) when retrieving a list of entities from Orb-API doesn’t work (any longer). Replace it with manual pagination (for now).