### PR TITLE
fix: write to database more frequently during manual sync

### DIFF
--- a/packages/orb-sync-lib/src/database/postgres.ts
+++ b/packages/orb-sync-lib/src/database/postgres.ts
@@ -1,6 +1,7 @@
 import pg from 'pg';
 import { pg as sql } from 'yesql';
 import type { JsonSchema } from '../schemas/types';
+import { randomUUID } from 'node:crypto';
 
 type PostgresConfig = {
   databaseUrl: string;
@@ -25,6 +26,8 @@ export class PostgresClient {
     const chunkSize = 5;
     const results: pg.QueryResult<T>[] = [];
 
+    const timerLoggingLabel = `upsert-many-${randomUUID()}`;
+    console.time(timerLoggingLabel);
     for (let i = 0; i < entries.length; i += chunkSize) {
       const chunk = entries.slice(i, i + chunkSize);
 
@@ -43,6 +46,7 @@ export class PostgresClient {
 
       results.push(...(await Promise.all(queries)));
     }
+    console.timeEnd(timerLoggingLabel);
 
     return results.flatMap((it) => it.rows);
   }


### PR DESCRIPTION
Write to database after each (pagination) request to Orb-API instead of at the very end.

**Context:**
When manually syncing a larger number of entities, we regularly run into Gateway Timeouts (504). Although most time is simply spent on requesting the Orb-API (and not on processing the returned data) we now write to the database more frequently instead of collecting thousands of entities before updating the database.

**In addition:**
We log the time spent on requesting the Orb-API and writing to the database