### PR TITLE
feat: updates subscription billing cycle on invoice.issued event

### DIFF
--- a/apps/node-fastify/.env.sample
+++ b/apps/node-fastify/.env.sample
@@ -16,3 +16,5 @@ ORB_API_KEY=test_
 # Optional
 PORT=8080
 
+# Optional, whether to verify the Orb webhook signature
+VERIFY_WEBHOOK_SIGNATURE=true

--- a/apps/node-fastify/src/app.ts
+++ b/apps/node-fastify/src/app.ts
@@ -42,6 +42,7 @@ export async function createApp(opts: FastifyServerOptions = {}): Promise<Fastif
     orbWebhookSecret: config.ORB_WEBHOOK_SECRET,
     databaseSchema: config.DATABASE_SCHEMA,
     orbApiKey: config.ORB_API_KEY,
+    verifyWebhookSignature: config.VERIFY_WEBHOOK_SIGNATURE,
   });
 
   app.decorate('orbSync', orbSync);

--- a/apps/node-fastify/src/utils/config.ts
+++ b/apps/node-fastify/src/utils/config.ts
@@ -19,6 +19,9 @@ type configType = {
 
   /** Access the Orb API */
   ORB_API_KEY?: string;
+
+  /** Whether to verify the Orb webhook signature */
+  VERIFY_WEBHOOK_SIGNATURE: boolean;
 };
 
 function getConfigFromEnv(key: string, defaultValue?: string): string {
@@ -40,6 +43,7 @@ export function getConfig(): configType {
     DATABASE_URL: getConfigFromEnv('DATABASE_URL'),
     ORB_WEBHOOK_SECRET: getConfigFromEnv('ORB_WEBHOOK_SECRET'),
     PORT: Number(getConfigFromEnv('PORT', '8080')),
+    VERIFY_WEBHOOK_SIGNATURE: getConfigFromEnv('VERIFY_WEBHOOK_SIGNATURE', 'true') === 'true',
   };
 
   assert(!Number.isNaN(config.PORT), 'PORT must be a number');

--- a/packages/orb-sync-lib/src/invoice-utils.ts
+++ b/packages/orb-sync-lib/src/invoice-utils.ts
@@ -1,0 +1,32 @@
+import { Invoice } from 'orb-billing/resources';
+
+const PLAN_LINE_ITEM_NAME_ENDS_IN = 'Plan';
+
+/**
+ * Returns the billing cycle the given invoice's plan line item applies to.
+ * If no plan line item is present, null is returned.
+ */
+export function getBillingCycleFromInvoice(invoice: Invoice): { start: string; end: string } | null {
+  const planLineItem = findPlanLineItem(invoice.line_items);
+
+  // No plan line item found.
+  // Is the case for e.g. invoices that include usage line items for the past billing cycle only or
+  // invoices that include a fixed price line item other than the plan line item only
+  if (!planLineItem) {
+    return null;
+  }
+
+  return {
+    start: planLineItem.start_date,
+    end: planLineItem.end_date,
+  };
+}
+
+function findPlanLineItem(lineItems: Invoice.LineItem[]): Invoice.LineItem | undefined {
+  return lineItems.find(
+    (item) =>
+      item.price?.price_type === 'fixed_price' &&
+      item.price.billable_metric === null &&
+      item.name.endsWith(PLAN_LINE_ITEM_NAME_ENDS_IN)
+  );
+}

--- a/packages/orb-sync-lib/src/sync/subscriptions.ts
+++ b/packages/orb-sync-lib/src/sync/subscriptions.ts
@@ -58,3 +58,28 @@ export async function fetchAndSyncSubscription(postgresClient: PostgresClient, o
 
   await syncSubscriptions(postgresClient, [subscription]);
 }
+
+export async function updateBillingCycle(
+  postgresClient: PostgresClient,
+  {
+    subscriptionId,
+    billingCycleStart,
+    billingCycleEnd,
+  }: {
+    subscriptionId: string;
+    billingCycleStart: string;
+    billingCycleEnd: string;
+  }
+) {
+  const isBillingCycleStartInThePast = new Date(billingCycleStart) < new Date();
+  const isBillingCycleEndInTheFuture = new Date(billingCycleEnd) > new Date();
+
+  if (!isBillingCycleStartInThePast || !isBillingCycleEndInTheFuture) {
+    console.info(
+      `Billing cycle of subscription ${subscriptionId} is not being updated. start (${billingCycleStart}) / end (${billingCycleEnd}) not suitable`
+    );
+    return;
+  }
+
+  return postgresClient.updateSubscriptionBillingCycle({ subscriptionId, billingCycleStart, billingCycleEnd });
+}


### PR DESCRIPTION
Orb currently has no webhook whenever a billing cycle is reset, so subscription billing cycle information may be outdated. As a workaround we check whether an issued invoice contains a plan line item. A plan line item bein present means that there was a billing cycle reset and you can find the billing cycle's start and end date in the line item.
