### PR TITLE
fix: increase webhook body limit

### DIFF
--- a/apps/node-fastify/src/routes/webhooks.ts
+++ b/apps/node-fastify/src/routes/webhooks.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from 'fastify';
 
 export default async function routes(fastify: FastifyInstance) {
   fastify.post('/webhooks', {
-    bodyLimit: 2097152,
+    bodyLimit: 5e6, // 5 MB
     handler: async (request, reply) => {
       const headers = request.headers;
       const body: { raw: Buffer } = request.body as { raw: Buffer };


### PR DESCRIPTION
We're seeing some webhooks up to 4MB.
