### PR TITLE
chore: prefix for orb-sync-lib to avoid external resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This server synchronizes your [Orb](https://www.withorb.com/) account to a Postg
 - This will not do an initial load of existing Orb data. You should use CSV loads for this. We might implement this in the future.
 - Backfill of data
 - Entities that are not supported through webhooks like plans and billable metrics
-- `orb-sync-lib` is not yet published as standalone npm package (could be used in serverless functions or anywhere else)
+- `@supabase/orb-sync-lib` is not yet published as standalone npm package (could be used in serverless functions or anywhere else)
 - Database migration not handled automatically, need to run migrations from `db/migrations` manually for now
 
 ## Supported Webhooks

--- a/apps/node-fastify/package.json
+++ b/apps/node-fastify/package.json
@@ -23,7 +23,7 @@
     "@sentry/node": "^9.14.0",
     "dotenv": "^16.5.0",
     "fastify": "^5.3.2",
-    "orb-sync-lib": "*"
+    "@supabase/orb-sync-lib": "*"
   },
   "devDependencies": {
     "pino-pretty": "^13.0.0",

--- a/apps/node-fastify/src/app.ts
+++ b/apps/node-fastify/src/app.ts
@@ -4,7 +4,7 @@ import './instrument';
 import fastify, { FastifyInstance, FastifyServerOptions } from 'fastify';
 import autoload from '@fastify/autoload';
 import path from 'node:path';
-import { OrbSync } from 'orb-sync-lib';
+import { OrbSync } from '@supabase/orb-sync-lib';
 import { getConfig } from './utils/config';
 import * as Sentry from '@sentry/node';
 import pino from 'pino';

--- a/apps/node-fastify/src/types/fastify.d.ts
+++ b/apps/node-fastify/src/types/fastify.d.ts
@@ -1,4 +1,4 @@
-import { OrbSync } from 'orb-sync-lib';
+import { OrbSync } from '@supabase/orb-sync-lib';
 
 declare module 'fastify' {
   interface FastifyInstance {

--- a/docker/Dockerfile.node-fastify
+++ b/docker/Dockerfile.node-fastify
@@ -12,6 +12,6 @@ WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=0 /app/apps/node-fastify .
 COPY --from=0 /app/node_modules/ ./node_modules
-COPY --from=0 /app/packages/orb-sync-lib/dist ./node_modules/orb-sync-lib
+COPY --from=0 /app/packages/orb-sync-lib/dist ./node_modules/@supabase/orb-sync-lib
 
 CMD ["npm", "start"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,9 @@
         "@fastify/autoload": "^6.3.0",
         "@fastify/type-provider-typebox": "^5.1.0",
         "@sentry/node": "^9.14.0",
+        "@supabase/orb-sync-lib": "*",
         "dotenv": "^16.5.0",
-        "fastify": "^5.3.2",
-        "orb-sync-lib": "*"
+        "fastify": "^5.3.2"
       },
       "devDependencies": {
         "pino-pretty": "^13.0.0",
@@ -1911,6 +1911,10 @@
       "integrity": "sha512-75232GRx3wp3P7NP+yc4nRK3XUAnaQShxTAzapgmQrgs0QvSq0/mOJGoZXRpH15cFCKyys+4laCPbBselqJ5Ag==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@supabase/orb-sync-lib": {
+      "resolved": "packages/orb-sync-lib",
+      "link": true
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -4123,10 +4127,6 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
-    "node_modules/orb-sync-lib": {
-      "resolved": "packages/orb-sync-lib",
-      "link": true
-    },
     "node_modules/orb-sync-node-fastify": {
       "resolved": "apps/node-fastify",
       "link": true
@@ -5829,6 +5829,7 @@
       "dev": true
     },
     "packages/orb-sync-lib": {
+      "name": "@supabase/orb-sync-lib",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/orb-sync-lib/package.json
+++ b/packages/orb-sync-lib/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "orb-sync-lib",
+  "name": "@supabase/orb-sync-lib",
   "version": "0.0.0",
   "description": "Library for syncing data from Orb to Postgres.",
   "main": "./dist/index.js",


### PR DESCRIPTION
Someone released an npm package called `orb-sync-lib` - prefixing this will ensure that this is not accidentally resolved externally and is using the local lib