### PR TITLE
chore(ci): Add healthcheck to Docker Compose setup 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,5 @@ jobs:
 
       - name: Tests
         run: |
-          docker compose -f ./docker/compose.yml up -d
+          docker compose -f ./docker/compose.yml up -d --wait
           npm run test

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -13,3 +13,8 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - ../db/migrations:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 1s
+      timeout: 3s
+      retries: 30


### PR DESCRIPTION
This PR ensures the database is fully ready before running integration tests in CI.

## What is the current behavior?

The CI pipeline occasionally fails with `Connection terminated unexpectedly` or `the database system is starting up` errors when running integration tests. This happens because tests begin executing before the Postgres container is fully initialized and ready to accept connections. Click [here](https://github.com/supabase/orb-sync-engine/actions/runs/15858352161/job/44709130366?pr=69) for an example.

![Screenshot 2025-06-24 at 4 11 40 PM](https://github.com/user-attachments/assets/cc01d93c-7bc9-4284-b75d-25937c672446)


## What is the new behavior?

Adds a `healthcheck` to the `db` service in `docker/compose.yml` and updates the CI workflow to use `docker compose up -d --wait`, ensuring the database is marked as healthy before tests are run.

This should eliminate the race condition.

![Screenshot 2025-06-24 at 4 15 36 PM](https://github.com/user-attachments/assets/ffec2b01-bb56-42d2-9d31-cff4d550d95c)
