### PR TITLE
chore: Add last_synced_at columns

### DIFF
--- a/db/migrations/0009_add_last_synced_at_columns.sql
+++ b/db/migrations/0009_add_last_synced_at_columns.sql
@@ -1,0 +1,21 @@
+-- Add last_synced_at column to all relevant entity tables
+-- This column tracks when each entity was last synchronized with Orb.
+-- It enables timestamp-based protection to prevent old webhooks from overwriting newer data.
+
+alter table orb.invoices
+add column last_synced_at timestamptz;
+
+alter table orb.customers
+add column last_synced_at timestamptz;
+
+alter table orb.subscriptions
+add column last_synced_at timestamptz;
+
+alter table orb.credit_notes
+add column last_synced_at timestamptz;
+
+alter table orb.plans
+add column last_synced_at timestamptz;
+
+alter table orb.billable_metrics
+add column last_synced_at timestamptz;


### PR DESCRIPTION
This PR adds the `last_synced_at` columns used by https://github.com/supabase/orb-sync-engine/pull/68 to prevent synced invoices from getting updated by outdated webhooks. The last_synced_at represents the last timestamp when we synced this entity with the entity in Orb.